### PR TITLE
Async patterns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ combine-as-imports = true
 
 [tool.pytest.ini_options]
 timeout = 20
+asyncio_mode = "auto"
 
 [tool.hatch.envs.default]
 installer = "uv"

--- a/src/paperoni/__main__.py
+++ b/src/paperoni/__main__.py
@@ -393,11 +393,10 @@ class Work:
 
         async def run(self, work: "Work"):
             statuses = {}
-            it = itertools.islice(work.top, self.n) if self.n else work.top
-            sets = list(it)
+            it = list(itertools.islice(work.top, self.n)) if self.n else work.top
 
             for i in range(self.loops):
-                for sws in prog(sets, name=f"refine{i + 1 if i else ''}"):
+                for sws in prog(it, name=f"refine{i + 1 if i else ''}"):
                     statuses.update(
                         {
                             (name, key): "done"

--- a/src/paperoni/collection/filecoll.py
+++ b/src/paperoni/collection/filecoll.py
@@ -22,7 +22,7 @@ class FileCollection(MemCollection):
 
         self.__dict__.update(vars(load(MemCollection, self.file)))
 
-    def _commit(self):
+    def _commit(self) -> None:
         dump(type(self), self, dest=self.file)
 
     @classmethod

--- a/src/paperoni/collection/memcoll.py
+++ b/src/paperoni/collection/memcoll.py
@@ -38,6 +38,9 @@ class MemCollection(PaperCollection):
         self._last_id += 1
         return self._last_id
 
+    async def add_papers(self, papers: Iterable[CollectionPaper]) -> int:
+        return self._add_papers(papers)
+
     def _add_papers(self, papers: Iterable[CollectionPaper]) -> int:
         added = 0
 
@@ -74,9 +77,6 @@ class MemCollection(PaperCollection):
 
         return added
 
-    async def add_papers(self, papers: Iterable[CollectionPaper]) -> int:
-        return self._add_papers(papers)
-
     async def exclude_papers(self, papers: Iterable[Paper]) -> None:
         for paper in papers:
             for link in getattr(paper, "links", []):
@@ -105,12 +105,12 @@ class MemCollection(PaperCollection):
 
         raise ValueError(f"Paper with ID {paper.id} not found in collection")
 
+    async def commit(self) -> None:
+        self._commit()
+
     def _commit(self) -> None:
         # MemCollection, nothing to commit
         pass
-
-    async def commit(self) -> None:
-        self._commit()
 
     async def drop(self) -> None:
         self._last_id = -1

--- a/src/paperoni/collection/mongocoll.py
+++ b/src/paperoni/collection/mongocoll.py
@@ -397,7 +397,7 @@ class MongoCollection(PaperCollection):
         async for doc in self._collection.find(query):
             yield deserialize(MongoPaper, doc)
 
-    async def _commit(self) -> None:
+    async def commit(self) -> None:
         # Commits are done synchronously to collections operations
         pass
 

--- a/src/paperoni/discovery/jmlr.py
+++ b/src/paperoni/discovery/jmlr.py
@@ -3,6 +3,7 @@ import re
 import traceback
 from datetime import date, datetime
 from traceback import print_exc
+from typing import Callable
 
 from outsight import send
 
@@ -41,7 +42,7 @@ class JMLR(Discoverer):
     ):
         """Query Journal of Machine Learning Research."""
         if volume is None:
-            for v in await self.list_volumes():
+            async for v in self.list_volumes():
                 async for paper in self.query(v, name, cache, focuses):
                     yield paper
             return
@@ -172,14 +173,20 @@ class JMLR(Discoverer):
                 info={"discovered_by": {"jmlr": jmlr_key}},
             )
 
-    async def extract_volumes(self, index, selector, map=None, filter=None):
+    async def extract_volumes(
+        self, index, selector, map: Callable = None, filter: Callable = None
+    ):
         main = await config.fetch.read(index, format="html")
         urls = [lnk.attrs["href"] for lnk in main.select(selector)]
-        return [map(url) if map else url for url in urls if filter is None or filter(url)]
+        for volume in (
+            map(url) if map else url for url in urls if filter is None or filter(url)
+        ):
+            yield volume
 
     async def list_volumes(self):
-        return await self.extract_volumes(
+        async for volume in self.extract_volumes(
             index=f"{self.urlbase}/papers",
             selector="a",
             filter=lambda url: url.startswith("v"),
-        )
+        ):
+            yield volume

--- a/src/paperoni/discovery/openreview.py
+++ b/src/paperoni/discovery/openreview.py
@@ -260,7 +260,7 @@ class OpenReview(Discoverer):
         else:
             return VenueType.unknown
 
-    def _query(self, params, total=0, limit=1000000):
+    async def _query(self, params, total=0, limit=1000000):
         next_offset = 0
         while total < limit:
             params["offset"] = next_offset
@@ -362,7 +362,9 @@ class OpenReview(Discoverer):
                 break
             total += next_offset
 
-    def _query_papers_from_venues(self, params, venues=None, total=0, limit=1000000):
+    async def _query_papers_from_venues(
+        self, params, venues=None, total=0, limit=1000000
+    ):
         if not venues:  # pragma: no cover
             venues = self.client.get_group(id="venues").members
 
@@ -374,7 +376,7 @@ class OpenReview(Discoverer):
                     "content": {**params["content"], "venueid": v},
                 }
 
-            for paper in self._query(params, total, limit):
+            async for paper in self._query(params, total, limit):
                 total += 1
                 yield paper
 
@@ -532,7 +534,7 @@ class OpenReview(Discoverer):
                 "content": {**params["content"], "title": title},
             }
 
-        for paper in self._query_papers_from_venues(params, venue, 0, limit):
+        async for paper in self._query_papers_from_venues(params, venue, 0, limit):
             yield paper
 
 

--- a/src/paperoni/discovery/semantic_scholar.py
+++ b/src/paperoni/discovery/semantic_scholar.py
@@ -134,7 +134,7 @@ AUTHOR_PAPERS_FIELDS = (
 class SemanticScholar(Discoverer):
     api_key: str = field(default_factory=lambda: config.api_keys.semantic_scholar)
 
-    async def _evaluate(self, path: str, **params):
+    async def _evaluate(self, path: str, **params) -> dict:
         jdata = await config.fetch.read_retry(
             f"https://api.semanticscholar.org/graph/v1/{path}",
             params=params,

--- a/src/paperoni/refinement/dblp.py
+++ b/src/paperoni/refinement/dblp.py
@@ -28,7 +28,7 @@ def _author_links(author_span):
 
 
 @register_fetch
-async def dblp(type: Literal["dblp"], link: str):
+async def dblp(typ: Literal["dblp"], link: str):
     data = await config.fetch.read_retry(
         f"https://dblp.uni-trier.de/rec/{link}.xml", format="xml"
     )
@@ -63,7 +63,7 @@ async def dblp(type: Literal["dblp"], link: str):
             )
             for author in data.select("author")
         ],
-        links=[Link(type=type, link=link), *extra_links],
+        links=[Link(type=typ, link=link), *extra_links],
         releases=[
             Release(
                 venue=Venue(

--- a/src/paperoni/refinement/doi.py
+++ b/src/paperoni/refinement/doi.py
@@ -24,7 +24,7 @@ from .formats import paper_from_crossref, paper_from_jats
 
 
 @register_fetch
-async def crossref(type: Literal["doi"], link: str):
+async def crossref(typ: Literal["doi"], link: str):
     """Fetch from CrossRef."""
 
     doi = link
@@ -50,7 +50,7 @@ async def crossref(type: Literal["doi"], link: str):
 
 
 @register_fetch
-async def datacite(type: Literal["doi", "arxiv"], link: str):
+async def datacite(typ: Literal["doi", "arxiv"], link: str):
     """
     Refine using DataCite.
 
@@ -59,7 +59,7 @@ async def datacite(type: Literal["doi", "arxiv"], link: str):
     API call reference: https://support.datacite.org/reference/get_dois-id
     DataCite metadata properties: https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/
     """
-    if type == "arxiv":
+    if typ == "arxiv":
         doi = f"10.48550/arXiv.{link}"
     else:
         doi = link
@@ -248,7 +248,7 @@ async def datacite(type: Literal["doi", "arxiv"], link: str):
 
 
 @register_fetch
-async def biorxiv(type: Literal["doi"], link: StartsWith["10.1101/"]):  # type: ignore
+async def biorxiv(typ: Literal["doi"], link: StartsWith["10.1101/"]):  # type: ignore
     async def _get(url):
         data = await config.fetch.read_retry(url, format="json")
         if (
@@ -276,7 +276,7 @@ async def biorxiv(type: Literal["doi"], link: StartsWith["10.1101/"]):  # type: 
 
 
 @register_fetch
-async def unpaywall(type: Literal["doi"], doi: str):
+async def unpaywall(typ: Literal["doi"], doi: str):
     try:
         data = await config.fetch.read_retry(
             f"https://api.unpaywall.org/v2/{doi}?email={config.mailto}",

--- a/src/paperoni/refinement/fetch.py
+++ b/src/paperoni/refinement/fetch.py
@@ -8,7 +8,7 @@ from ..utils import soft_fail
 
 
 @ovld
-async def fetch(type: str, link: str):
+async def fetch(typ: str, link: str):
     return None
 
 
@@ -85,6 +85,7 @@ async def fetch_all(links, group="composite", statuses=None, tags=None, force=Fa
         for f in fs:
             if not _test_tags(getattr(f.func, "tags", {"normal"}), tags):
                 continue
+
             name = getattr(f.func, "description", "???")
             nk = f"{name}/{key}"
             if nk in statuses:

--- a/src/paperoni/refinement/llm_html.py
+++ b/src/paperoni/refinement/llm_html.py
@@ -42,11 +42,11 @@ async def prompt(link: str, send_input, force: bool = False) -> Paper:
 
 
 @register_fetch(tags={"prompt", "html"})
-async def html(type: Literal["doi"], link: str, *, force: bool = False) -> Paper:
+async def html(typ: Literal["doi"], link: str, *, force: bool = False) -> Paper:
     paper = await prompt(
-        f"https://doi.org/{link}", send_input=f"{type}:{link}", force=force
+        f"https://doi.org/{link}", send_input=f"{typ}:{link}", force=force
     )
-    paper.links.append(Link(type=type, link=link))
+    paper.links.append(Link(type=typ, link=link))
     return paper.authors and paper or None
 
 

--- a/src/paperoni/refinement/pubmed.py
+++ b/src/paperoni/refinement/pubmed.py
@@ -7,7 +7,7 @@ from .formats import paper_from_jats
 
 
 @register_fetch
-async def pubmed(type: Literal["pmc"], link: str):
+async def pubmed(typ: Literal["pmc"], link: str):
     pmc_id = link
     soup = await config.fetch.read(
         # PubMed Central OAI-PMH API : https://pmc.ncbi.nlm.nih.gov/tools/oai/

--- a/src/paperoni/refinement/title.py
+++ b/src/paperoni/refinement/title.py
@@ -10,7 +10,7 @@ from .formats import paper_from_crossref
 
 
 @register_fetch
-async def crossref_title(type: Literal["title"], link: str):
+async def crossref_title(typ: Literal["title"], link: str):
     """Fetch from Crossref by title search."""
 
     title = link
@@ -44,26 +44,18 @@ async def crossref_title(type: Literal["title"], link: str):
 
 
 @register_fetch
-async def openalex_title(type: Literal["title"], link: str):
+async def openalex_title(typ: Literal["title"], link: str):
     """Fetch from OpenAlex by title search."""
 
     title = link
 
     qm = OpenAlexQueryManager(mailto=config.mailto)
 
-    papers = [
-        p
-        async for p in qm.works(
-            filter=f"display_name.search:{title.strip().replace(',', '')}",
-            data_version="1",
-            limit=1,
-        )
-    ]
-
-    if not papers:
-        return None
-
-    paper = papers[0].paper
-    if paper.title != title:
-        return None
-    return paper
+    async for paper in qm.works(
+        filter=f"display_name.search:{title.strip().replace(',', '')}",
+        data_version="1",
+        limit=1,
+    ):
+        paper = paper.paper
+        if paper.title == title:
+            return paper

--- a/src/paperoni/web/restapi.py
+++ b/src/paperoni/web/restapi.py
@@ -302,8 +302,11 @@ def install_api(app) -> FastAPI:
     async def search_papers(request: SearchRequest = Depends(parse_search_request)):
         """Search for papers in the collection."""
         coll = Coll(command=None)
+
+        # Perform search using the collection's search method
         all_matches = await request.run(coll)
         results = list(request.slice(all_matches))
+
         return SearchResponse(
             results=results,
             count=request.count,

--- a/tests/discovery/test_jmlr.py
+++ b/tests/discovery/test_jmlr.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
 from paperoni.discovery.jmlr import JMLR
@@ -7,11 +6,12 @@ from paperoni.model import PaperInfo
 from ..utils import check_papers
 
 
-@pytest.mark.asyncio
 async def test_query(data_regression: DataRegressionFixture):
     discoverer = JMLR()
 
-    assert "v24" in (await discoverer.list_volumes())
+    assert "v24" in [v async for v in discoverer.list_volumes()], (
+        "Could not find volume v24"
+    )
 
     papers: list[PaperInfo] = sorted(
         [p async for p in discoverer.query(volume="v24", name="Yoshua Bengio")],

--- a/tests/discovery/test_miniconf.py
+++ b/tests/discovery/test_miniconf.py
@@ -10,7 +10,6 @@ from paperoni.model import PaperInfo
 from ..utils import check_papers, iter_affiliations
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ["conference", "query_params"],
     itertools.product(
@@ -62,7 +61,6 @@ async def test_query(data_regression: DataRegressionFixture, conference, query_p
     check_papers(data_regression, papers)
 
 
-@pytest.mark.asyncio
 async def test_error_policy(capsys):
     discoverer = MiniConf()
 

--- a/tests/discovery/test_openalex.py
+++ b/tests/discovery/test_openalex.py
@@ -20,7 +20,6 @@ PAPERS = [
 ]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query_params",
     [
@@ -118,7 +117,6 @@ async def test_query(
     check_papers(data_regression, papers)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query_params",
     [
@@ -139,7 +137,6 @@ async def test_query_error(query_params):
         await anext(discoverer.query(**query_params))
 
 
-@pytest.mark.asyncio
 async def test_query_limit_ignored_when_focuses_provided(capsys: pytest.CaptureFixture):
     discoverer = OpenAlex()
     results = [
@@ -170,7 +167,6 @@ async def test_query_limit_ignored_when_focuses_provided(capsys: pytest.CaptureF
     )
 
 
-@pytest.mark.asyncio
 async def test_focuses_drive_discovery_false():
     """Test that focuses with drive_discovery=False are skipped."""
     discoverer = OpenAlex()
@@ -189,7 +185,6 @@ async def test_focuses_drive_discovery_false():
     assert len(results) == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ["query_params", "focused_params"],
     [
@@ -279,7 +274,6 @@ async def test_focuses(query_params, focused_params):
         assert result.score == 10.0
 
 
-@pytest.mark.asyncio
 async def test_focuses_multiple_focuses():
     """Test multiple focuses with different types."""
     discoverer = OpenAlex()

--- a/tests/discovery/test_openreview.py
+++ b/tests/discovery/test_openreview.py
@@ -9,7 +9,6 @@ from paperoni.model.focus import Focus, Focuses
 from ..utils import check_papers, iter_links_ids, iter_releases
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query_params",
     [
@@ -131,7 +130,6 @@ async def test_query(
     check_papers(data_regression, papers)
 
 
-@pytest.mark.asyncio
 async def test_query_limit_ignored_when_focuses_provided(capsys: pytest.CaptureFixture):
     discoverer = OpenReviewDispatch()
     results = [
@@ -160,7 +158,6 @@ async def test_query_limit_ignored_when_focuses_provided(capsys: pytest.CaptureF
     )
 
 
-@pytest.mark.asyncio
 async def test_focuses_drive_discovery_false():
     """Test that focuses with drive_discovery=False are skipped."""
     discoverer = OpenReviewDispatch()
@@ -176,7 +173,6 @@ async def test_focuses_drive_discovery_false():
     assert len(results) == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ["query_params", "focused_params"],
     [

--- a/tests/discovery/test_pmlr.py
+++ b/tests/discovery/test_pmlr.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 
 from paperoni.discovery.pmlr import PMLR
@@ -7,11 +6,12 @@ from paperoni.model import PaperInfo
 from ..utils import check_papers
 
 
-@pytest.mark.asyncio
 async def test_query(data_regression: DataRegressionFixture):
     discoverer = PMLR()
 
-    assert "v180" in (await discoverer.list_volumes()), "Could not find volume v180"
+    assert "v180" in [v async for v in discoverer.list_volumes()], (
+        "Could not find volume v180"
+    )
 
     papers: list[PaperInfo] = sorted(
         [p async for p in discoverer.query(volume="v180", name="Yoshua Bengio")],

--- a/tests/discovery/test_scrape.py
+++ b/tests/discovery/test_scrape.py
@@ -16,7 +16,6 @@ def touch_cache():
         _f.touch()
 
 
-@pytest.mark.asyncio
 async def test_query(data_regression: DataRegressionFixture):
     discoverer = Scrape()
 

--- a/tests/discovery/test_semantic_scholar.py
+++ b/tests/discovery/test_semantic_scholar.py
@@ -23,7 +23,6 @@ PAPERS = [
 ]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query_params",
     [
@@ -104,7 +103,6 @@ async def test_query(
     check_papers(data_regression, papers)
 
 
-@pytest.mark.asyncio
 async def test_query_limit_ignored_when_focuses_provided(capsys: pytest.CaptureFixture):
     discoverer = SemanticScholar()
     results = [
@@ -134,7 +132,6 @@ async def test_query_limit_ignored_when_focuses_provided(capsys: pytest.CaptureF
     )
 
 
-@pytest.mark.asyncio
 async def test_focuses_drive_discovery_false():
     """Test that focuses with drive_discovery=False are skipped."""
     discoverer = SemanticScholar()
@@ -149,7 +146,6 @@ async def test_focuses_drive_discovery_false():
     assert len(results) == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ["query_params", "focused_params"],
     [

--- a/tests/fulltext/test_pdf.py
+++ b/tests/fulltext/test_pdf.py
@@ -3,7 +3,6 @@ import pytest
 from paperoni.fulltext.pdf import CachePolicies, get_pdf
 
 
-@pytest.mark.asyncio
 async def test_get_pdf(file_regression):
     ref = "openreview:vieIamY2Gi"
 
@@ -14,7 +13,6 @@ async def test_get_pdf(file_regression):
     file_regression.check(p.meta_path.read_text())
 
 
-@pytest.mark.asyncio
 async def test_get_best_pdf():
     ref1 = "openreview:G7X1hsBLNl"
     ref2 = "arxiv:2506.10137"

--- a/tests/model/test_focus.py
+++ b/tests/model/test_focus.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import gifnoc
-import pytest
 from pytest_regressions.data_regression import DataRegressionFixture
 from serieux import CommentRec, deserialize, dump, serialize
 
@@ -192,7 +191,6 @@ def test_focuses_top():
     assert snd.value.paper.title == "Paper from Alice"
 
 
-@pytest.mark.asyncio
 async def test_focuses_update(tmp_path: Path, data_regression: DataRegressionFixture):
     with gifnoc.overlay(
         {

--- a/tests/refinement/test_fetch.py
+++ b/tests/refinement/test_fetch.py
@@ -107,7 +107,6 @@ links_w_redirect_errors = {
 }
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(["func", "link"], links)
 async def test_refine(func, link, data_regression):
     typ, link = link.split(":", 1)
@@ -125,7 +124,6 @@ async def test_refine(func, link, data_regression):
             raise
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ["func", "link"],
     [

--- a/tests/refinement/test_formats.py
+++ b/tests/refinement/test_formats.py
@@ -13,7 +13,6 @@ rors = {
 }
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("name,ror_id", rors.items())
 async def test_ror(name, ror_id, data_regression):
     inst = await institution_from_ror(ror_id)

--- a/tests/refinement/test_llm_html.py
+++ b/tests/refinement/test_llm_html.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,7 +13,7 @@ from tests.utils import check_papers
 
 
 @pytest.fixture(scope="module")
-def paper_info():
+async def paper_info():
     # Prepared with:
     # paperoni refine --link "doi:10.1038/s41597-023-02214-y" --tags html --norm
     with (
@@ -24,37 +23,33 @@ def paper_info():
             lambda *args, **kwargs: "DUMMY_KEY",
         ),
     ):
-
-        async def get():
-            assert (
-                next(
-                    filter(
-                        lambda pinfo: "html" in pinfo.info["refined_by"],
-                        [
-                            p
-                            async for p in fetch_all(
-                                [("doi", "10.1038/s41597-023-02214-y")], tags={}
-                            )
-                        ],
-                    ),
-                    None,
-                )
-                is None
-            )
-
-            return next(
+        assert (
+            next(
                 filter(
                     lambda pinfo: "html" in pinfo.info["refined_by"],
                     [
                         p
                         async for p in fetch_all(
-                            [("doi", "10.1038/s41597-023-02214-y")], tags={"html"}
+                            [("doi", "10.1038/s41597-023-02214-y")], tags={}
                         )
                     ],
-                )
+                ),
+                None,
             )
+            is None
+        )
 
-        yield asyncio.run(get())
+        yield next(
+            filter(
+                lambda pinfo: "html" in pinfo.info["refined_by"],
+                [
+                    p
+                    async for p in fetch_all(
+                        [("doi", "10.1038/s41597-023-02214-y")], tags={"html"}
+                    )
+                ],
+            )
+        )
 
 
 def test_html(data_regression: DataRegressionFixture, paper_info: PaperInfo):

--- a/tests/refinement/test_llm_norm.py
+++ b/tests/refinement/test_llm_norm.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -13,17 +12,11 @@ from tests.utils import check_papers
 
 
 @pytest.fixture(scope="module")
-def paper_info():
+async def paper_info():
     # Prepared with:
     # paperoni refine --link "doi:10.1109/cvpr52733.2024.01307" --norm
     with gifnoc.overlay({"paperoni.data_path": str(Path(__file__).parent / "data")}):
-
-        async def get():
-            return await anext(
-                fetch_all([("doi", "10.1109/cvpr52733.2024.01307")], tags={})
-            )
-
-        yield asyncio.run(get())
+        yield await anext(fetch_all([("doi", "10.1109/cvpr52733.2024.01307")], tags={}))
 
 
 def test_norm(data_regression: DataRegressionFixture, paper_info: PaperInfo):

--- a/tests/refinement/test_llm_pdf.py
+++ b/tests/refinement/test_llm_pdf.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,7 +13,7 @@ from tests.utils import check_papers
 
 
 @pytest.fixture(scope="module")
-def paper_info():
+async def paper_info():
     # Prepared with:
     # paperoni refine --link "openreview:_3FyT_W1DW" --tags pdf --norm
     with (
@@ -23,37 +22,26 @@ def paper_info():
             "paperoni.refinement.llm_pdf._make_key", lambda *args, **kwargs: "DUMMY_KEY"
         ),
     ):
-
-        async def get():
-            assert (
-                next(
-                    filter(
-                        lambda pinfo: "pdf" in pinfo.info["refined_by"],
-                        [
-                            p
-                            async for p in fetch_all(
-                                [("openreview", "_3FyT_W1DW")], tags={}
-                            )
-                        ],
-                    ),
-                    None,
-                )
-                is None
-            )
-
-            return next(
+        assert (
+            next(
                 filter(
                     lambda pinfo: "pdf" in pinfo.info["refined_by"],
-                    [
-                        p
-                        async for p in fetch_all(
-                            [("openreview", "_3FyT_W1DW")], tags={"pdf"}
-                        )
-                    ],
-                )
+                    [p async for p in fetch_all([("openreview", "_3FyT_W1DW")], tags={})],
+                ),
+                None,
             )
+            is None
+        )
 
-        yield asyncio.run(get())
+        yield next(
+            filter(
+                lambda pinfo: "pdf" in pinfo.info["refined_by"],
+                [
+                    p
+                    async for p in fetch_all([("openreview", "_3FyT_W1DW")], tags={"pdf"})
+                ],
+            )
+        )
 
 
 def test_pdf(data_regression: DataRegressionFixture, paper_info: PaperInfo):

--- a/tests/test_work.py
+++ b/tests/test_work.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from pathlib import Path
 from time import sleep
 
-import pytest
 from serieux import CommentRec, dump, load
 
 from paperoni.__main__ import Work
@@ -32,7 +31,6 @@ async def work(command, **kwargs):
     return load(Top[Scored[CommentRec[PaperWorkingSet, float]]], work_file)
 
 
-@pytest.mark.asyncio
 async def test_work_get_does_not_duplicate(tmp_path: Path):
     state = await work(
         Work.Get(command=SemanticScholar().query),
@@ -64,7 +62,6 @@ async def test_work_get_does_not_duplicate(tmp_path: Path):
         await mem_col.add_papers([paper])
 
 
-@pytest.mark.asyncio
 async def test_work_get_does_not_duplicate_collection_papers(tmp_path: Path):
     await work(
         Work.Get(command=SemanticScholar().query),
@@ -87,7 +84,6 @@ async def test_work_get_does_not_duplicate_collection_papers(tmp_path: Path):
         assert await col.find_paper(paper) is None
 
 
-@pytest.mark.asyncio
 async def test_work_updates_collection_papers(tmp_path: Path):
     state = await work(
         Work.Get(command=SemanticScholar().query),


### PR DESCRIPTION
# Async patterns

- **Pytest async mode**: Enable `asyncio_mode = "auto"` to remove redundant `@pytest.mark.asyncio` decorators
- **Async generators**: Convert list-returning methods to async generators (e.g., `list_volumes()`, `extract_volumes()`)
- **Type hints**: Add return type annotations and fix parameter naming (`type` -> `typ` to avoid shadowing builtin)
- **Test fixtures**: Convert sync fixtures to async where appropriate
